### PR TITLE
Multiple Mods (ctoken support; fix doorsensor state "removed"; make it work with older HA instance

### DIFF
--- a/custom_components/nuki_ng/manifest.json
+++ b/custom_components/nuki_ng/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/kvj/hass_nuki_ng/issues",
   "dependencies": [],
   "codeowners": ["@kvj"],
-  "requirements": [],
+  "requirements": ["pynacl"],
   "iot_class": "local_polling",
   "config_flow": true,
   "version": "0.2.1"

--- a/custom_components/nuki_ng/nuki.py
+++ b/custom_components/nuki_ng/nuki.py
@@ -1,6 +1,9 @@
 from hashlib import sha256
-from random import randint
 from socket import timeout
+from random import random
+
+from numpy import int16
+
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -12,7 +15,12 @@ import requests
 import logging
 import json
 import re
-from datetime import timedelta, datetime, timezone
+import hashlib
+import nacl.utils
+import nacl.secret
+import random
+import datetime 
+from datetime import timedelta, timezone
 from urllib.parse import urlencode
 
 from .constants import DOMAIN
@@ -31,7 +39,7 @@ class NukiInterface:
         self.bridge = bridge
         self.token = token
         self.web_token = web_token
-        self.use_hashed = False
+        self.use_hashed = use_hashed
 
     async def async_json(self, cb):
         response = await self.hass.async_add_executor_job(lambda: cb(requests))
@@ -60,11 +68,23 @@ class NukiInterface:
             # Port inside
             url = f"http://{self.bridge}"
         if self.use_hashed:
-            tz = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-            rnr = randint(0, 65535)
-            to_hash = "%s,%s,%s" % (tz, rnr, self.token)
-            hashed = sha256(to_hash.encode("utf-8")).hexdigest()
-            return f"{url}{path}?ts={tz}&rnr={rnr}&hash={hashed}{extra_str}"
+            # create parts of plaintext content
+            rnr = str(random.randrange(0,65535))
+            date = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+            time = datetime.datetime.utcnow().strftime("%H:%M:%S")
+            s_plaintext_token = str(date) + "T" + str(time) + "Z," + rnr
+            # calc NaCl box key
+            s_key = hashlib.sha256(str(self.token).encode('utf-8')).digest()
+            # calc nonce for ctoken / according to libsoldium docu
+            s_nonce_raw = nacl.utils.random(24)
+            box = nacl.secret.SecretBox(s_key)
+            # create crypted token from plaintext
+            ctoken = box.encrypt(s_plaintext_token.encode('utf-8'), s_nonce_raw)
+            # convert token and nonce to hex string
+            s_ctoken_hex_str = ctoken.ciphertext.hex()
+            session_nonce_hex_str = s_nonce_raw.hex()
+            return f"{url}{path}?ctoken={s_ctoken_hex_str}&nonce={session_nonce_hex_str}{extra_str}"
+
         return f"{url}{path}?token={self.token}{extra_str}"
 
     async def bridge_list(self):
@@ -73,6 +93,7 @@ class NukiInterface:
         for item in data:
             result[item.get("nukiId")] = item
         return result
+
 
     async def bridge_info(self):
         return await self.async_json(lambda r: r.get(self.bridge_url("/info"), timeout=BRIDGE_TIMEOUT))

--- a/custom_components/nuki_ng/nuki.py
+++ b/custom_components/nuki_ng/nuki.py
@@ -349,7 +349,6 @@ class NukiCoordinator(DataUpdateCoordinator):
             "bridge",
             hook_id,
             handler=self._make_bridge_hook_handler(),
-            local_only=True,
         )
 
     def _add_update(self, dev_id: str, update):

--- a/custom_components/nuki_ng/sensor.py
+++ b/custom_components/nuki_ng/sensor.py
@@ -103,6 +103,15 @@ class RSSI(NukiEntity, SensorEntity):
 
 
 class DoorSensorState(NukiEntity, SensorEntity):
+    door_state_map = {1: "deactivated",
+                      2: "door closed",
+                      3: "door opened",
+                      4: "door state unknown",
+                      5: "calibrating",
+                      16: "uncalibrated",
+                      240: "removed",
+                      255: "unknown"}
+
     def __init__(self, coordinator, device_id):
         super().__init__(coordinator, device_id)
         self.set_id("sensor", "door_state")
@@ -110,9 +119,8 @@ class DoorSensorState(NukiEntity, SensorEntity):
         self._attr_icon = "mdi:door"
 
     @property
-    def state(self):
-        return self.last_state.get("doorsensorStateName")
-
+    def state(self):        
+        return self.door_state_map.get(self.last_state.get("doorsensorState"))
     @property
     def entity_category(self):
         return EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
These are multiple mods for myself:
* support ctoken authentication / this is automatically used, once config value "used_hashed" is set to true
According to NUKI bridge API doc https://developer.nuki.io/page/nuki-bridge-http-api-1-13/4 - the hashed token method is deprecated by the introduction of this new method (but will remain available in the API in order to not break existing integrations until at least end of 2022)
ctoken methode securely protect the plaintext bridge api token even against attackers who have access to the local network.

* fixed doorsensor state "removed" (240). Bridge FW 2.14.0 reports the door sensor state (new door sensor with bluetooth connection to nuki) as string "tampered" although in parallel the numeric state is reported as 240 (which according to API docu is "removed")
Thus now "removed" is shown in the door sensor state than "tampered"

* revoked change https://github.com/kvj/hass_nuki_ng/pull/47 since my HA instance does no support this property for webhooks